### PR TITLE
Add support for packetdiag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Blockdiag Preprocessor for Foliant
 
-[Blockdiag](http://blockdiag.com/) is a tool to generate diagrams from plain text. This preprocessor finds diagram definitions in the source and converts them into images on the fly during project build. It supports all Blockdiag flavors: blockdiag, seqdiag, actdiag, and nwdiag.
+[Blockdiag](http://blockdiag.com/) is a tool to generate diagrams from plain text. This preprocessor finds diagram definitions in the source and converts them into images on the fly during project build. It supports all Blockdiag flavors: blockdiag, seqdiag, actdiag, nwdiag and rackdiag.
 
 
 ## Installation
@@ -29,6 +29,7 @@ preprocessors:
       seqdiag_path: seqdiag
       actdiag_path: actdiag
       nwdiag_path: nwdiag
+      rackdiag_path: rackdiag
       params:
         ...
 ```
@@ -41,7 +42,7 @@ preprocessors:
     >   To save time during build, only new and modified diagrams are rendered. The generated images are cached and reused in future builds.
 
 `*_path`
-:   Paths to the `blockdiag`, `seqdiag`, `actdiag`, and `nwdiag` binaries. By default, it is assumed that you have these commands in `PATH`, but if they're installed in a custom place, you can define it here.
+:   Paths to the `blockdiag`, `seqdiag`, `actdiag`, `nwdiag` and `rackdiag` binaries. By default, it is assumed that you have these commands in `PATH`, but if they're installed in a custom place, you can define it here.
 
 `params`
 :   Params passed to the image generation commands (`blockdiag`, `seqdiag`, etc.). Params should be defined by their long names, with dashes replaced with underscores (e.g. `--no-transparency` becomes `no_transparency`); also, `-T` param is called `format` for readability:
@@ -57,7 +58,7 @@ preprocessors:
 
 ## Usage
 
-To insert a diagram definition in your Markdown source, enclose it between `<<blockdiag>...</blockdiag>`, `<<seqdiag>...</seqdiag>`, `<actdiag>...</actdiag>`, or `<nwdiag>...</nwdiag>` tags (indentation inside tags is optional):
+To insert a diagram definition in your Markdown source, enclose it between `<<blockdiag>...</blockdiag>`, `<<seqdiag>...</seqdiag>`, `<actdiag>...</actdiag>`, `<nwdiag>...</nwdiag>`, or `<rackdiag>...</rackdiag>` tags (indentation inside tags is optional):
 
 ```markdown
 Here's a block diagram:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Blockdiag Preprocessor for Foliant
 
-[Blockdiag](http://blockdiag.com/) is a tool to generate diagrams from plain text. This preprocessor finds diagram definitions in the source and converts them into images on the fly during project build. It supports all Blockdiag flavors: blockdiag, seqdiag, actdiag, nwdiag and rackdiag.
+[Blockdiag](http://blockdiag.com/) is a tool to generate diagrams from plain text. This preprocessor finds diagram definitions in the source and converts them into images on the fly during project build. It supports all Blockdiag flavors: actdiag, blockdiag, nwdiag, packetdiag, rackdiag, and seqdiag.
 
 
 ## Installation
@@ -25,11 +25,12 @@ The preprocessor has a number of options:
 preprocessors:
   - blockdiag:
       cache_dir: !path .diagramscache
-      blockdiag_path: blockdiag
-      seqdiag_path: seqdiag
       actdiag_path: actdiag
+      blockdiag_path: blockdiag
       nwdiag_path: nwdiag
+      packetdiag_path: packetdiag
       rackdiag_path: rackdiag
+      seqdiag_path: seqdiag
       params:
         ...
 ```
@@ -42,7 +43,7 @@ preprocessors:
     >   To save time during build, only new and modified diagrams are rendered. The generated images are cached and reused in future builds.
 
 `*_path`
-:   Paths to the `blockdiag`, `seqdiag`, `actdiag`, `nwdiag` and `rackdiag` binaries. By default, it is assumed that you have these commands in `PATH`, but if they're installed in a custom place, you can define it here.
+:   Paths to the `actdiag`, `blockdiag`, `nwdiag`, `packetdiag`, `rackdiag`, or `seqdiag` binaries. By default, it is assumed that you have these commands in `PATH`, but if they're installed in a custom place, you can define it here.
 
 `params`
 :   Params passed to the image generation commands (`blockdiag`, `seqdiag`, etc.). Params should be defined by their long names, with dashes replaced with underscores (e.g. `--no-transparency` becomes `no_transparency`); also, `-T` param is called `format` for readability:
@@ -58,12 +59,12 @@ preprocessors:
 
 ## Usage
 
-To insert a diagram definition in your Markdown source, enclose it between `<<blockdiag>...</blockdiag>`, `<<seqdiag>...</seqdiag>`, `<actdiag>...</actdiag>`, `<nwdiag>...</nwdiag>`, or `<rackdiag>...</rackdiag>` tags (indentation inside tags is optional):
+To insert a diagram definition in your Markdown source, enclose it between `<actdiag>...</actdiag>`, `<blockdiag>...</blockdiag>`, `<nwdiag>...</nwdiag>`, `<packetdiag>...</packetdiag>`, `<rackdiag>...</rackdiag>`, or `<seqdiag>...</seqdiag>` tags (indentation inside tags is optional):
 
 ```markdown
 Here's a block diagram:
 
-<<blockdiag>
+<blockdiag>
   blockdiag {
     A -> B -> C -> D;
     A -> E -> F -> G;
@@ -72,7 +73,7 @@ Here's a block diagram:
 
 Here's a sequence diagram:
 
-<<seqdiag>
+<seqdiag>
   seqdiag {
     browser  -> webserver [label = "GET /index.html"];
     browser <-- webserver;
@@ -89,7 +90,7 @@ To set a caption, use `caption` option:
 ```markdown
 Diagram with a caption:
 
-<<blockdiag caption="Sample diagram from the official site">
+<blockdiag caption="Sample diagram from the official site">
   blockdiag {
     A -> B -> C -> D;
     A -> E -> F -> G;
@@ -102,7 +103,7 @@ You can override `params` values from the preprocessor config for each diagram:
 ```markdown
 By default, diagrams are in png. But this diagram is in svg:
 
-<<blockdiag caption="High-quality diagram" format="svg">
+<blockdiag caption="High-quality diagram" format="svg">
   blockdiag {
     A -> B -> C -> D;
     A -> E -> F -> G;

--- a/foliant/preprocessors/blockdiag.py
+++ b/foliant/preprocessors/blockdiag.py
@@ -19,9 +19,10 @@ class Preprocessor(BasePreprocessor):
         'blockdiag_path': 'blockdiag',
         'seqdiag_path': 'seqdiag',
         'actdiag_path': 'actdiag',
-        'nwdiag_path': 'nwdiag'
+        'nwdiag_path': 'nwdiag',
+        'rackdiag_path': 'rackdiag'
     }
-    tags = 'blockdiag', 'seqdiag', 'actdiag', 'nwdiag'
+    tags = 'blockdiag', 'seqdiag', 'actdiag', 'nwdiag', 'rackdiag'
 
     def _get_command(
             self,
@@ -32,7 +33,7 @@ class Preprocessor(BasePreprocessor):
         '''Generate the image generation command. Options from the config definition are passed
         as command options (``cache_dir`` and ``*_path`` options are omitted).
 
-        :param kind: Diagram kind: blockdiag, seqdiag, actdiag, or nwdiag
+        :param kind: Diagram kind: blockdiag, seqdiag, actdiag, nwdiag or rackdiag
         :param options: Options extracted from the diagram definition
         :param diagram_src_path: Path to the diagram source file
 
@@ -67,7 +68,7 @@ class Preprocessor(BasePreprocessor):
         If the image for this diagram has already been generated, the existing version
         is used.
 
-        :param kind: Diagram kind: blockdiag, seqdiag, actdiag, or nwdiag
+        :param kind: Diagram kind: blockdiag, seqdiag, actdiag, nwdiag, rackdiag
         :param options: Options extracted from the diagram definition
         :param body: Diagram body
 

--- a/foliant/preprocessors/blockdiag.py
+++ b/foliant/preprocessors/blockdiag.py
@@ -1,6 +1,6 @@
-'''`Blockdiag <http://blockdiag.com/>`__ preprocessor for Foliant documenation authoring tool.
+'''`Blockdiag <http://blockdiag.com/>`__ preprocessor for Foliant documentation authoring tool.
 
-Supports blockdiag, seqdiag, actdiag, and nwdiag.
+Supports actdiag, blockdiag, nwdiag, packetdiag, rackdiag, and seqdiag
 '''
 
 from pathlib import Path
@@ -16,13 +16,21 @@ from foliant.utils import output
 class Preprocessor(BasePreprocessor):
     defaults = {
         'cache_dir': Path('.diagramscache'),
-        'blockdiag_path': 'blockdiag',
-        'seqdiag_path': 'seqdiag',
         'actdiag_path': 'actdiag',
+        'blockdiag_path': 'blockdiag',
         'nwdiag_path': 'nwdiag',
-        'rackdiag_path': 'rackdiag'
+        'packetdiag_path': 'packetdiag',
+        'rackdiag_path': 'rackdiag',
+        'seqdiag_path': 'seqdiag',
     }
-    tags = 'blockdiag', 'seqdiag', 'actdiag', 'nwdiag', 'rackdiag'
+    tags = (
+        'actdiag',
+        'blockdiag',
+        'nwdiag',
+        'packetdiag',
+        'rackdiag',
+        'seqdiag',
+    )
 
     def _get_command(
             self,
@@ -33,7 +41,7 @@ class Preprocessor(BasePreprocessor):
         '''Generate the image generation command. Options from the config definition are passed
         as command options (``cache_dir`` and ``*_path`` options are omitted).
 
-        :param kind: Diagram kind: blockdiag, seqdiag, actdiag, nwdiag or rackdiag
+        :param kind: Diagram kind: actdiag, blockdiag, nwdiag, packetdiag, rackdiag, or seqdiag
         :param options: Options extracted from the diagram definition
         :param diagram_src_path: Path to the diagram source file
 
@@ -68,7 +76,7 @@ class Preprocessor(BasePreprocessor):
         If the image for this diagram has already been generated, the existing version
         is used.
 
-        :param kind: Diagram kind: blockdiag, seqdiag, actdiag, nwdiag, rackdiag
+        :param kind: Diagram kind: actdiag, blockdiag, nwdiag, packetdiag, rackdiag, or seqdiag
         :param options: Options extracted from the diagram definition
         :param body: Diagram body
 


### PR DESCRIPTION
This adds support for the `packetdiag` diagrams, and folds in @griznog's pull request #2, which added `rackdiag`, so that the two don't generate conflicts.
